### PR TITLE
Add translations for Föli username and password

### DIFF
--- a/auth_backends/templates/foli/login.html
+++ b/auth_backends/templates/foli/login.html
@@ -2,7 +2,7 @@
 
 {% load i18n bootstrap4 %}
 
-{% block title %}{% trans "Library card login" %}{% endblock %}
+{% block title %}{% trans "Föli login" %}{% endblock %}
 
 {% block content %}
 <form action="{% url 'social:begin' backend='foli' %}" method='post' class='form'{% if form.id %} id='{{ form.id }}'{% endif %}{% if form.non_field_errors %} aria-errormessage='{{ form.id }}-errors'{% endif %}>

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Tunnistamo\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-28 09:27+0000\n"
+"POT-Creation-Date: 2023-03-31 05:41+0000\n"
 "PO-Revision-Date: 2019-04-17 07:55+0000\n"
 "Last-Translator: Timo Tuominen <dev@hel.fi>, 2019\n"
 "Language-Team: Finnish (https://www.transifex.com/city-of-helsinki-1/"
@@ -40,7 +40,7 @@ msgstr "Väärä kortinnumero tai PIN-koodi"
 
 #: auth_backends/foli.py
 msgid "Föli username"
-msgstr "Föli käyttäjätunnus"
+msgstr "Föli-käyttäjätunnus"
 
 #: auth_backends/foli.py
 msgid "Password"
@@ -51,7 +51,6 @@ msgid "Invalid username or password"
 msgstr "Virheellinen käyttäjätunnus tai salasana"
 
 #: auth_backends/templates/axiell_aurora/login.html
-#: auth_backends/templates/foli/login.html
 #: auth_backends/templates/koha/login.html
 msgid "Library card login"
 msgstr "Tunnistaudu kirjastokortilla"
@@ -67,6 +66,10 @@ msgstr "Kirjaudu"
 #: auth_backends/templates/koha/login.html
 msgid "Return to login method selection"
 msgstr "Palaa tunnistautumismenetelmän valintaan"
+
+#: auth_backends/templates/foli/login.html
+msgid "Föli login"
+msgstr "Kirjaudu Föli-tunnuksilla"
 
 #: content/models.py
 msgid "site owner name"

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -11,41 +11,60 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Tunnistamo\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-11-13 18:57+0200\n"
+"POT-Creation-Date: 2023-03-28 09:27+0000\n"
 "PO-Revision-Date: 2019-04-17 07:55+0000\n"
 "Last-Translator: Timo Tuominen <dev@hel.fi>, 2019\n"
-"Language-Team: Finnish (https://www.transifex.com/city-of-helsinki-1/teams/98217/fi/)\n"
+"Language-Team: Finnish (https://www.transifex.com/city-of-helsinki-1/"
+"teams/98217/fi/)\n"
 "Language: fi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: auth_backends/adfs/turku.py
+#: auth_backends/adfs/opas.py auth_backends/adfs/turku.py
 msgid "Your AD account does not have an associated OID"
 msgstr "AD-käyttäjätunnukseesi ei ole merkitty OID-tunnistetta"
 
-#: auth_backends/axiell_aurora.py
+#: auth_backends/axiell_aurora.py auth_backends/koha.py
 msgid "Library card identifier"
 msgstr "Kirjastokortin tunnus"
 
-#: auth_backends/axiell_aurora.py
+#: auth_backends/axiell_aurora.py auth_backends/koha.py
 msgid "Card PIN"
 msgstr "Tunnusluku (PIN)"
 
-#: auth_backends/axiell_aurora.py
+#: auth_backends/axiell_aurora.py auth_backends/koha.py
 msgid "Invalid card number or PIN"
 msgstr "Väärä kortinnumero tai PIN-koodi"
 
+#: auth_backends/foli.py
+msgid "Föli username"
+msgstr "Föli käyttäjätunnus"
+
+#: auth_backends/foli.py
+msgid "Password"
+msgstr "Salasana"
+
+#: auth_backends/foli.py
+msgid "Invalid username or password"
+msgstr "Virheellinen käyttäjätunnus tai salasana"
+
 #: auth_backends/templates/axiell_aurora/login.html
+#: auth_backends/templates/foli/login.html
+#: auth_backends/templates/koha/login.html
 msgid "Library card login"
 msgstr "Tunnistaudu kirjastokortilla"
 
 #: auth_backends/templates/axiell_aurora/login.html
+#: auth_backends/templates/foli/login.html
+#: auth_backends/templates/koha/login.html
 msgid "Login"
 msgstr "Kirjaudu"
 
 #: auth_backends/templates/axiell_aurora/login.html
+#: auth_backends/templates/foli/login.html
+#: auth_backends/templates/koha/login.html
 msgid "Return to login method selection"
 msgstr "Palaa tunnistautumismenetelmän valintaan"
 

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -2,51 +2,70 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Henrik Andersson <dev@hel.fi>, 2019
 # Katarina Pada <katarina.pada@turku.fi>, 2019
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-11-19 16:13+0100\n"
+"POT-Creation-Date: 2023-03-28 09:27+0000\n"
 "PO-Revision-Date: 2019-11-19 15:14+0000\n"
 "Last-Translator: Katarina Pada <katarina.pada@turku.fi>, 2019\n"
-"Language-Team: Swedish (https://www.transifex.com/city-of-helsinki/teams/104963/sv/)\n"
+"Language-Team: Swedish (https://www.transifex.com/city-of-helsinki/"
+"teams/104963/sv/)\n"
+"Language: sv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: sv\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: auth_backends/adfs/turku.py
+#: auth_backends/adfs/opas.py auth_backends/adfs/turku.py
 msgid "Your AD account does not have an associated OID"
 msgstr "Ditt AD-konto har inget anslutet OID"
 
-#: auth_backends/axiell_aurora.py
+#: auth_backends/axiell_aurora.py auth_backends/koha.py
 msgid "Library card identifier"
 msgstr "Identifiering med bibliotekskort"
 
-#: auth_backends/axiell_aurora.py
+#: auth_backends/axiell_aurora.py auth_backends/koha.py
 msgid "Card PIN"
 msgstr "Kortets PIN-kod"
 
-#: auth_backends/axiell_aurora.py
+#: auth_backends/axiell_aurora.py auth_backends/koha.py
 msgid "Invalid card number or PIN"
 msgstr "Ogiltigt kortnummer eller PIN-kod"
 
+#: auth_backends/foli.py
+msgid "Föli username"
+msgstr "Användarnamn på Föli"
+
+#: auth_backends/foli.py
+msgid "Password"
+msgstr "Lösenord"
+
+#: auth_backends/foli.py
+msgid "Invalid username or password"
+msgstr "Ogiltigt användarnamn eller lösenord"
+
 #: auth_backends/templates/axiell_aurora/login.html
+#: auth_backends/templates/foli/login.html
+#: auth_backends/templates/koha/login.html
 msgid "Library card login"
 msgstr "Inloggning med bibliotekskort"
 
 #: auth_backends/templates/axiell_aurora/login.html
+#: auth_backends/templates/foli/login.html
+#: auth_backends/templates/koha/login.html
 msgid "Login"
 msgstr "Inloggning"
 
 #: auth_backends/templates/axiell_aurora/login.html
+#: auth_backends/templates/foli/login.html
+#: auth_backends/templates/koha/login.html
 msgid "Return to login method selection"
 msgstr "Retur till val av inloggning"
 

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-28 09:27+0000\n"
+"POT-Creation-Date: 2023-03-31 05:41+0000\n"
 "PO-Revision-Date: 2019-11-19 15:14+0000\n"
 "Last-Translator: Katarina Pada <katarina.pada@turku.fi>, 2019\n"
 "Language-Team: Swedish (https://www.transifex.com/city-of-helsinki/"
@@ -52,7 +52,6 @@ msgid "Invalid username or password"
 msgstr "Ogiltigt användarnamn eller lösenord"
 
 #: auth_backends/templates/axiell_aurora/login.html
-#: auth_backends/templates/foli/login.html
 #: auth_backends/templates/koha/login.html
 msgid "Library card login"
 msgstr "Inloggning med bibliotekskort"
@@ -68,6 +67,10 @@ msgstr "Inloggning"
 #: auth_backends/templates/koha/login.html
 msgid "Return to login method selection"
 msgstr "Retur till val av inloggning"
+
+#: auth_backends/templates/foli/login.html
+msgid "Föli login"
+msgstr "Inloggning med Föli"
 
 #: content/models.py
 msgid "site owner name"


### PR DESCRIPTION
# Add username and password translations to Föli login method's login form

## Description

In #39 Föli integration backend was added with a custom template (`auth_backends/templates/foli/login.html`). Translations weren't included in that PR, so they are added in this PR. 

Note: I closed #43 and created a new one, because of the following warning in the closed PR: ![image](https://user-images.githubusercontent.com/121616850/228228677-1270f41b-ee68-4608-ad6b-30f9c0c7a44b.png)
