### PR TITLE
Fix login page losing query params on login errors

### DIFF
--- a/auth_backends/axiell_aurora.py
+++ b/auth_backends/axiell_aurora.py
@@ -111,10 +111,17 @@ class AuroraAuth(LegacyAuth):
             form = AuroraLoginForm()
 
         login_method_uri = reverse('login')
-        if request.GET:
-            login_method_uri += '?' + urlencode(request.GET)
+        query_string = ''
 
-        return render(request, self.FORM_HTML, {'form': form, 'login_method_uri': login_method_uri})
+        if request.GET:
+            query_string = urlencode(request.GET)
+            login_method_uri += '?' + query_string
+
+        return render(request, self.FORM_HTML, {
+            'form': form,
+            'login_method_uri': login_method_uri,
+            'query_string': query_string,
+        })
 
     def _validate_settings(self):
         REQUIRED_SETTINGS = ['API_URL', 'API_USERNAME', 'API_PASSWORD']

--- a/auth_backends/foli.py
+++ b/auth_backends/foli.py
@@ -102,10 +102,17 @@ class FoliAuth(LegacyAuth):
             form = FoliLoginForm()
 
         login_method_uri = reverse('login')
-        if request.GET:
-            login_method_uri += '?' + urlencode(request.GET)
+        query_string = ''
 
-        return render(request, self.FORM_HTML, {'form': form, 'login_method_uri': login_method_uri})
+        if request.GET:
+            query_string = urlencode(request.GET)
+            login_method_uri += '?' + query_string
+
+        return render(request, self.FORM_HTML, {
+            'form': form,
+            'login_method_uri': login_method_uri,
+            'query_string': query_string,
+        })
 
     def _validate_settings(self):
         REQUIRED_SETTINGS = ['API_URL']

--- a/auth_backends/koha.py
+++ b/auth_backends/koha.py
@@ -106,10 +106,17 @@ class KohaAuth(LegacyAuth):
             form = KohaLoginForm()
 
         login_method_uri = reverse('login')
-        if request.GET:
-            login_method_uri += '?' + urlencode(request.GET)
+        query_string = ''
 
-        return render(request, self.FORM_HTML, {'form': form, 'login_method_uri': login_method_uri})
+        if request.GET:
+            query_string = urlencode(request.GET)
+            login_method_uri += '?' + query_string
+
+        return render(request, self.FORM_HTML, {
+            'form': form,
+            'login_method_uri': login_method_uri,
+            'query_string': query_string,
+        })
 
     def _validate_settings(self):
         REQUIRED_SETTINGS = ['API_URL']

--- a/auth_backends/templates/axiell_aurora/login.html
+++ b/auth_backends/templates/axiell_aurora/login.html
@@ -5,7 +5,7 @@
 {% block title %}{% trans "Library card login" %}{% endblock %}
 
 {% block content %}
-<form action="{% url 'social:begin' backend='axiell_aurora' %}" method='post' class='form'{% if form.id %} id='{{ form.id }}'{% endif %}{% if form.non_field_errors %} aria-errormessage='{{ form.id }}-errors'{% endif %}>
+<form action="{% url 'social:begin' backend='axiell_aurora' %}?{{ query_string }}" method='post' class='form'{% if form.id %} id='{{ form.id }}'{% endif %}{% if form.non_field_errors %} aria-errormessage='{{ form.id }}-errors'{% endif %}>
   {% csrf_token %}
   {% bootstrap_form form %}
   {% buttons %}

--- a/auth_backends/templates/foli/login.html
+++ b/auth_backends/templates/foli/login.html
@@ -5,7 +5,7 @@
 {% block title %}{% trans "Föli login" %}{% endblock %}
 
 {% block content %}
-<form action="{% url 'social:begin' backend='foli' %}" method='post' class='form'{% if form.id %} id='{{ form.id }}'{% endif %}{% if form.non_field_errors %} aria-errormessage='{{ form.id }}-errors'{% endif %}>
+<form action="{% url 'social:begin' backend='foli' %}?{{ query_string }}" method='post' class='form'{% if form.id %} id='{{ form.id }}'{% endif %}{% if form.non_field_errors %} aria-errormessage='{{ form.id }}-errors'{% endif %}>
   {% csrf_token %}
   {% bootstrap_form form %}
   {% buttons %}

--- a/auth_backends/templates/koha/login.html
+++ b/auth_backends/templates/koha/login.html
@@ -5,7 +5,7 @@
 {% block title %}{% trans "Library card login" %}{% endblock %}
 
 {% block content %}
-<form action="{% url 'social:begin' backend='koha' %}" method='post' class='form'{% if form.id %} id='{{ form.id }}'{% endif %}{% if form.non_field_errors %} aria-errormessage='{{ form.id }}-errors'{% endif %}>
+<form action="{% url 'social:begin' backend='koha' %}?{{ query_string }}" method='post' class='form'{% if form.id %} id='{{ form.id }}'{% endif %}{% if form.non_field_errors %} aria-errormessage='{{ form.id }}-errors'{% endif %}>
   {% csrf_token %}
   {% bootstrap_form form %}
   {% buttons %}


### PR DESCRIPTION
# Fix login page losing query params on login errors

## Description

When user comes to Tunnistamo via a client, the user is provided some of the possible login methods for the client that have been accepted. Some login methods include a login form page in Tunnistamo. Föli and Koha (authentication backend for Vaski library card) are examples of this. These login pages include a back button which leads back to the login method page. When user provides wrong authentication information in the login form, the page drops it query parameters which the back button needs to provide just the login methods that have been accepted by the client where user came from. When this happens, the user can see all possible login methods in Tunnistamo. This PR fixes that problem.