### PR TITLE
Fix translation for info_profile

### DIFF
--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -334,7 +334,7 @@ msgstr "Grundläggande profil"
 msgid ""
 "Access to your basic information, which includes your first and last names."
 msgstr ""
-"Åtkomst till din grundinformation, vilket inkluderar ditt för- och "
+"Åtkomst till din grundinformation, vilket inkluderar dina för- och "
 "efternamn."
 
 #: oidc_apis/scopes.py


### PR DESCRIPTION
# Fix Swedish translation for `profile` scope description 

## Description

We have defined a description for `profile` scope through `info_profile` in `oidc_apis/scopes.py`:  

```python
info_profile = (                                                                                                                                                                                                                                                                          
    _(u'Basic profile'),
    _(u'Access to your basic information. Includes names, gender, birthdate ' 
      'and other information.'),
) 
```

The Swedish translation for the latter text has been defined as follows `locale/sv/LC_MESSAGES/django.po`:

```po
#: oidc_apis/scopes.py
msgid ""
"Access to your basic information, which includes your first and last names."
msgstr ""
"Åtkomst till din grundinformation, vilket inkluderar ditt för- och "
"efternamn."
```  

But we received a fix request for the translation:

```diff
#: oidc_apis/scopes.py
msgid ""
"Access to your basic information, which includes your first and last names."
msgstr ""
+ "Åtkomst till din grundinformation, vilket inkluderar dina för- och "
- "Åtkomst till din grundinformation, vilket inkluderar ditt för- och "
"efternamn."
```

**TLDR**: we need to change the word *ditt* to *dina*.