### PR TITLE
Add new intermediate characters to personal identity code parsing in Suomi.fi auth backend

### DIFF
--- a/auth_backends/turku_suomifi.py
+++ b/auth_backends/turku_suomifi.py
@@ -72,11 +72,11 @@ class TurkuSuomiFiAuth(LegacyAuth):
 
         birthdate = attrs.get('nationalIdentificationNumber', '')
         if birthdate:
-            m = re.match(r'([0-9]{2})([0-9]{2})([0-9]{2})([A-])', birthdate)
+            m = re.match(r'([0-9]{2})([0-9]{2})([0-9]{2})([A-FU-Y-])', birthdate)
             if not m:
                 raise AuthFailed(self, 'Invalid birth date: %s' % birthdate)
             day, month, year, century = m.groups()
-            if century == 'A':
+            if century in 'ABCDEF':
                 year = '20' + year
             else:
                 year = '19' + year


### PR DESCRIPTION
# New intermediate characters to personal identity code parsing

## Description

A new decree on new intermediate characters was entered into force this on 1 January 2023. First personal identity codes with new intermediate characters are going to be issued next year, on Janury 2024. This needs to be taken into account in Tunnistamo which handles personal identity codes by parsing a birthdate from the personal identity codes in Turku's Suomi.fi auth backend.

Information about the change: https://dvv.fi/hetu-uudistus (FI) & https://dvv.fi/en/reform-of-personal-identity-code (EN)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Auth backends
  1. `auth_backends/turku_suomifi.py`
     * Regex matching and birthdate creation includes new intermediate characters