### PR TITLE
Add uncommited .gitignore lines from production to repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,7 @@
 .python-version
 .coverage
 .cache
+.env
 .idea
+/certs
 /data


### PR DESCRIPTION
#  Add uncommited lines .gitignore lines from production to repository

## Description

During the latest production releases, it came up, that there are some uncommited lines added to `.gitignore` in production. 

The diff for the uncommited lines:

```diff
diff --git a/.gitignore b/.gitignore
index f5da30f..12d77d7 100644
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,7 @@
 .python-version
 .coverage
 .cache
+.env
 .idea
+/certs
 /data
```

The lines should be added to the repository as well because no environment variable files or certificate keys should be made public:

- `.env`: [tunnistamo/settings.py](https://github.com/City-of-Turku/tunnistamo/blob/2755ac9bca4b4b45b53a33e2012cdc5030e5d156/tunnistamo/settings.py#L62-L63)
- `/certs`: [Docs/turku-production.md](https://github.com/City-of-Turku/tunnistamo/blob/2755ac9bca4b4b45b53a33e2012cdc5030e5d156/Docs/turku-production.md?plain=1#L61)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Add the vc-ignored paths
  1. `.gitignore`
     * Added `.env` and `/certs`